### PR TITLE
fix chat section feedback

### DIFF
--- a/resources/js/src/pages/Chat.jsx
+++ b/resources/js/src/pages/Chat.jsx
@@ -83,10 +83,12 @@ const Chat = () => {
         })
             .then(({data}) => {
                 setFeedBackVisible(false);
+                setFeedbackLoading(false);
             })
             .catch(() => {
                 console.error('error sending feedback');
                 setFeedBackVisible(false);
+                setFeedbackLoading(false);
             });
     }
 


### PR DESCRIPTION
closes #22 

Set feedback loading to false after submitting initial feedback in the chat page.